### PR TITLE
add fix for click through on search section overlay on mobile

### DIFF
--- a/components/TheHeaderSearch.vue
+++ b/components/TheHeaderSearch.vue
@@ -1,13 +1,13 @@
 <template>
-  <section id="search" role="search" ref="autoSuggest">
+  <section id="search" role="search" ref="autoSuggest" :class="{'search-open': searchOpen}">
     <div class="inner-container" :class="{ 'results-visible': resultsVisible && searchQuery }">
-      <button class="toggle-search" title="Search" @click.prevent="toggleSearch" :class="{'search-open': searchOpen}">
+      <button class="toggle-search" title="Search" @click.prevent="toggleSearch">
         <svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" :class="{ 'results-visible': searchQuery && resultsVisible }">
           <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
           <path d="M0 0h24v24H0z" fill="none"/>
         </svg>
       </button>
-      <div class="input-container" ref="inputContainer" :class="{'search-open': searchOpen}">
+      <div class="input-container" ref="inputContainer">
         <input name="search" placeholder="Search articles" ref="searchQuery" type="text" v-model="searchQuery"
           @keyup.prevent="debounceSearch($event)"
           @keydown.prevent.enter="enter"
@@ -170,7 +170,12 @@ export default {
 
 section {
   margin-left: auto;
+  pointer-events: none;
   z-index: 1;
+
+  &.search-open {
+      pointer-events: all;
+  }
 
   @media (max-width: 700px) {
     margin: 0;
@@ -213,6 +218,7 @@ section {
     height: 100%;
     justify-content: center;
     position: absolute;
+    pointer-events: all;
 
     &:hover {
       svg {
@@ -278,7 +284,7 @@ section {
     width: 0;
     will-change: width;
 
-    &.search-open {
+    section.search-open & {
       width: 476px;
 
       @media (max-width: 700px) {


### PR DESCRIPTION
just a slight fix for when you are on the topic page and can't click the first item because the hidden search section lays over.